### PR TITLE
Switch networks: only show available chains

### DIFF
--- a/packages/frontend/src/views/Dashboard/ApplicationDetail/Chains.js
+++ b/packages/frontend/src/views/Dashboard/ApplicationDetail/Chains.js
@@ -18,7 +18,7 @@ export default function BasicSetup({ appData }) {
   const { isLoading: isChainsLoading, data: chains } = useQuery(
     "/network/chains",
     async function getNetworkChains() {
-      const path = `${env("BACKEND_URL")}/api/network/chains`;
+      const path = `${env("BACKEND_URL")}/api/network/stakeable-chains`;
 
       try {
         const res = await axios.get(path, {


### PR DESCRIPTION
Right now, the page's querying for _all_ chains available, when we actually want to filter for the ones that are ready in the pool.