### PR TITLE
API(ApplicationController, LoadBalancerController): convert on-chain apps to JSON to consume properties

### DIFF
--- a/packages/backend/src/controllers/ApplicationController.ts
+++ b/packages/backend/src/controllers/ApplicationController.ts
@@ -1,5 +1,6 @@
 import express, { Response, Request } from 'express'
 import { GraphQLClient } from 'graphql-request'
+import { typeGuard, QueryAppResponse } from '@pokt-network/pocket-js'
 import { GetApplicationQuery } from './types'
 import env from '../environment'
 import { getSdk } from '../graphql/types'
@@ -175,11 +176,22 @@ router.get(
     }
     const app = await getApp(application.freeTierApplicationAccount.address)
 
+    if (!typeGuard(app, QueryAppResponse)) {
+      throw HttpError.INTERNAL_SERVER_ERROR({
+        errors: [
+          {
+            id: 'POCKET_JS_ERROR',
+            message: 'Application could not be fetched.',
+          },
+        ],
+      })
+    }
+
+    const readableApp = app.toJSON()
+
     res.status(200).send({
-      // @ts-ignore
-      stake: app.stakedTokens,
-      // @ts-ignore
-      relays: app.maxRelays,
+      stake: readableApp.staked_tokens,
+      relays: readableApp.max_relays,
     })
   })
 )

--- a/packages/backend/src/controllers/LoadBalancerController.ts
+++ b/packages/backend/src/controllers/LoadBalancerController.ts
@@ -336,16 +336,13 @@ router.get(
       })
     }
 
-    const readableApps = apps.map((app) => app.toJSON())
+    const readableApps = apps.map((app: QueryAppResponse) => app.toJSON())
 
-    // @ts-ignore
     const appsStatus = readableApps.reduce(
       (status, app) => {
         return {
-          // @ts-ignore
           stake: app.staked_tokens + status.stake,
-          // @ts-ignore
-          relays: app.maxRelays + status.relays,
+          relays: app.max_relays + status.relays,
         }
       },
       {


### PR DESCRIPTION
Uses the `toJSON` property of the `QueryAppResponse` type to actually be able to read the properties of the type. A bit weird that we have to do this, but it works.