### PR TITLE
Auth: fix verify email error not being sent

### DIFF
--- a/packages/backend/src/controllers/UserController.ts
+++ b/packages/backend/src/controllers/UserController.ts
@@ -136,7 +136,10 @@ router.post(
           next(
             HttpError.BAD_REQUEST({
               errors: [
-                { id: 'NOT_VALIDATED', message: 'Please verify your email' },
+                {
+                  id: 'NOT_VALIDATED',
+                  message: 'Please verify your email. Check your inbox!',
+                },
               ],
             })
           )

--- a/packages/backend/src/controllers/UserController.ts
+++ b/packages/backend/src/controllers/UserController.ts
@@ -92,7 +92,7 @@ async function createNewVerificationToken(
  */
 router.post(
   '/login',
-  asyncMiddleware(async (req: Request, res: Response, next) => {
+  asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
     passport.authenticate(
       'login',
       { session: false },
@@ -133,11 +133,13 @@ router.post(
             templateName: 'SignUp',
             toEmail: user.email,
           })
-          throw HttpError.BAD_REQUEST({
-            errors: [
-              { id: 'NOT_VALIDATED', message: 'Please verify your email' },
-            ],
-          })
+          next(
+            HttpError.BAD_REQUEST({
+              errors: [
+                { id: 'NOT_VALIDATED', message: 'Please verify your email' },
+              ],
+            })
+          )
         }
 
         createCookieFromToken(user, 200, req, res)


### PR DESCRIPTION
Left the error throwing instead of passing it to `next`, as we're using passport here. Closes #168.