### PR TITLE
Backend(PocketJS): switch to new protobuf encoder

### DIFF
--- a/packages/backend/src/lib/pocket.ts
+++ b/packages/backend/src/lib/pocket.ts
@@ -42,7 +42,8 @@ const POCKET_CONFIGURATION = new Configuration(
   Number(blockTime),
   undefined,
   undefined,
-  false
+  false,
+  true
 )
 
 export const POKT_DENOMINATIONS = {


### PR DESCRIPTION
** DO NOT MERGE UNTIL BLOCK 30024 (Or the one chosen by PIP-6) LANDS **.

Switches to using the new Protobuf encoder instead of Amino for sending transactions 🙌 .