### PR TITLE
fix(pocket): move to healthy pocketJS version + inline config

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@pokt-foundation/pocket-dashboard-shared": "^0.0.3-alpha.0",
-    "@pokt-network/pocket-js": "^0.6.13-rc",
+    "@pokt-network/pocket-js": "0.6.12-rc",
     "@sendgrid/client": "^7.4.2",
     "@sendgrid/mail": "^7.4.2",
     "@types/mongoose": "^5.10.5",

--- a/packages/backend/src/lib/pocket.ts
+++ b/packages/backend/src/lib/pocket.ts
@@ -21,28 +21,30 @@ import env, { PocketNetworkKeys } from '../environment'
 const {
   blockTime,
   chainId,
-  dispatchers,
   freeTierFundAccount,
   freeTierFundAddress,
-  httpProviderNode,
-  maxSessions,
-  providerType,
-  requestTimeout,
   transactionFee,
 } = env('POCKET_NETWORK') as PocketNetworkKeys
 
-const MAX_DISPATCHERS = 24
+const DEFAULT_DISPATCHER_LIST = 'https://mainnet-1.nodes.pokt.network:4201,https://mainnet-2.nodes.pokt.network:4202,https://mainnet-3.nodes.pokt.network:4203,https://mainnet-4.nodes.pokt.network:4204,https://mainnet-5.nodes.pokt.network:4205,https://mainnet-6.nodes.pokt.network:4206,https://mainnet-7.nodes.pokt.network:4207,https://mainnet-8.nodes.pokt.network:4208,https://mainnet-9.nodes.pokt.network:4209,https://mainnet-10.nodes.pokt.network:4210,https://mainnet-11.nodes.pokt.network:4211,https://mainnet-12.nodes.pokt.network:4212,https://mainnet-13.nodes.pokt.network:4213,https://mainnet-14.nodes.pokt.network:4214,https://mainnet-15.nodes.pokt.network:4215,https://mainnet-16.nodes.pokt.network:4216,https://mainnet-17.nodes.pokt.network:4217,https://mainnet-18.nodes.pokt.network:4218,https://mainnet-19.nodes.pokt.network:4219,https://mainnet-20.nodes.pokt.network:4220,https://mainnet-21.nodes.pokt.network:4221,https://mainnet-22.nodes.pokt.network:4222,https://mainnet-23.nodes.pokt.network:4223,https://mainnet-24.nodes.pokt.network:4224'
+  .split(',')
+  .map((uri) => new URL(uri))
+const DEFAULT_HTTP_PROVIDER_NODE = 'https://mainnet-1.nodes.pokt.network:4201/'
+const DEFAULT_MAX_DISPATCHERS = 24
+const DEFAULT_MAX_SESSIONS = 1000000
+const DEFAULT_MAX_SESSION_RETRIES = 1
+const DEFAULT_REQUEST_TIMEOUT = 60 * 1000
 
 const POCKET_CONFIGURATION = new Configuration(
-  MAX_DISPATCHERS,
-  Number(maxSessions),
+  DEFAULT_MAX_DISPATCHERS,
+  DEFAULT_MAX_SESSIONS,
   0,
-  Number(requestTimeout),
-  undefined,
+  DEFAULT_REQUEST_TIMEOUT,
+  false,
   undefined,
   Number(blockTime),
-  undefined,
-  undefined,
+  DEFAULT_MAX_SESSION_RETRIES,
+  false,
   false,
   false
 )
@@ -53,27 +55,11 @@ export const POKT_DENOMINATIONS = {
 }
 
 function getPocketDispatchers() {
-  if (dispatchers === '') {
-    return []
-  }
-  return dispatchers.split(',').map(function (dispatcherUri) {
-    return new URL(dispatcherUri)
-  })
-}
-
-function getHttpRPCProvider(): HttpRpcProvider {
-  if (!httpProviderNode || httpProviderNode === '') {
-    throw new Error(`Invalid HTTP Provider Node: ${httpProviderNode}`)
-  }
-  return new HttpRpcProvider(new URL(httpProviderNode))
+  return DEFAULT_DISPATCHER_LIST
 }
 
 function getRPCProvider(): HttpRpcProvider | PocketRpcProvider {
-  if (providerType.toLowerCase() === 'http') {
-    return getHttpRPCProvider()
-  } else {
-    return getHttpRPCProvider()
-  }
+  return new HttpRpcProvider(new URL(DEFAULT_HTTP_PROVIDER_NODE))
 }
 
 export async function getNodes(status: number): Promise<Node[]> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4228,6 +4228,34 @@
     "@tendermint/belt" "0.2.1"
     "@tendermint/types" "0.1.1"
 
+"@pokt-network/pocket-js@0.6.12-rc":
+  version "0.6.12-rc"
+  resolved "https://registry.yarnpkg.com/@pokt-network/pocket-js/-/pocket-js-0.6.12-rc.tgz#227350e76c259d1e41676632bc62c142a34cc8ba"
+  integrity sha512-qgyzEMaxpr7Fh5XvO9MzL7S9RWS9QyOJNhq86REG2sYgiyl0MgDdYvRm/fvPcCkjkZAJyNKuKKedPGGsro3/ag==
+  dependencies:
+    "@pokt-network/aat-js" "0.1.1-rc"
+    "@pokt-network/amino-js" "0.7.5-alpha.1"
+    "@tendermint/belt" "^0.2.1"
+    "@types/aes-js" "^3.1.0"
+    "@types/libsodium-wrappers" "^0.7.7"
+    "@types/scrypt-js" "^2.0.4"
+    "@types/varint" "^6.0.0"
+    aes-js "^3.1.2"
+    axios "^0.21.1"
+    bigint-conversion "^2.1.12"
+    browserify "^16.5.1"
+    buffer "^5.6.0"
+    js-sha256 "^0.9.0"
+    js-sha3 "^0.8.0"
+    libsodium-wrappers "^0.7.6"
+    minifyify "^7.3.5"
+    node-localstorage "^2.1.5"
+    pbkdf2 "^3.0.17"
+    scrypt-js "^3.0.1"
+    ts-proto "^1.76.0"
+    tsify "^4.0.1"
+    varint "^6.0.0"
+
 "@pokt-network/pocket-js@^0.6.13-rc":
   version "0.6.13-rc"
   resolved "https://registry.yarnpkg.com/@pokt-network/pocket-js/-/pocket-js-0.6.13-rc.tgz#4a06d97a99d8fd700dba0ba7865a75c16f6dc5a4"


### PR DESCRIPTION
No need to have these in environment variables now—they're all closed nodes. This way we don't have to randomly trigger jobs if we change secrets.