### PR TITLE
Apps: limit to 4 per user

### DIFF
--- a/packages/frontend/src/components/MenuPanel/MenuPanel.js
+++ b/packages/frontend/src/components/MenuPanel/MenuPanel.js
@@ -18,6 +18,7 @@ import PortalLogo from '../../assets/portal_logo.svg'
 import { log, shorten } from 'lib/utils'
 
 const CHILD_INSTANCE_HEIGHT = 6 * GU
+const MAX_USER_APPS = 4
 
 const MENU_ROUTES = [
   {
@@ -66,17 +67,21 @@ export default function MenuPanel({ appsLoading = true, userApps = [] }) {
 
     groups.push([MENU_ROUTES[1]])
 
-    if (userApps.length) {
-      groups[1].push(
-        ...userApps.map(({ name, id }) => ({
-          label: name,
-          id: `/app/${id}`,
-          appId: id,
-        }))
-      )
+    if (!userApps.length) {
+      return groups
     }
 
-    groups[1].push(...CREATE_APP_ROUTE)
+    groups[1].push(
+      ...userApps.map(({ name, id }) => ({
+        label: name,
+        id: `/app/${id}`,
+        appId: id,
+      }))
+    )
+
+    if (userApps.length < MAX_USER_APPS) {
+      groups[1].push(...CREATE_APP_ROUTE)
+    }
 
     return groups
   }, [userApps])

--- a/packages/frontend/src/components/MenuPanel/MenuPanel.js
+++ b/packages/frontend/src/components/MenuPanel/MenuPanel.js
@@ -16,9 +16,9 @@ import IconApp from 'components/MenuPanel/IconApp'
 import IconNetwork from 'components/MenuPanel/IconNetwork'
 import PortalLogo from '../../assets/portal_logo.svg'
 import { log, shorten } from 'lib/utils'
+import { MAX_USER_APPS } from 'lib/pocket-utils'
 
 const CHILD_INSTANCE_HEIGHT = 6 * GU
-const MAX_USER_APPS = 4
 
 const MENU_ROUTES = [
   {

--- a/packages/frontend/src/lib/pocket-utils.js
+++ b/packages/frontend/src/lib/pocket-utils.js
@@ -1,3 +1,5 @@
+export const MAX_USER_APPS = 4
+
 /**
  * Shorten a Pocket address, `charsLength` allows to change the number of
  * characters on both sides of the ellipsis.

--- a/packages/frontend/src/views/Dashboard/Create/Create.js
+++ b/packages/frontend/src/views/Dashboard/Create/Create.js
@@ -27,6 +27,7 @@ import Box from 'components/Box/Box'
 import FloatUp from 'components/FloatUp/FloatUp'
 import { useUserApps } from 'contexts/AppsContext'
 import { log } from 'lib/utils'
+import { MAX_USER_APPS } from 'lib/pocket-utils'
 import env from 'environment'
 import {
   KNOWN_MUTATION_SUFFIXES,
@@ -231,7 +232,7 @@ export default function Create() {
   })
 
   useEffect(() => {
-    if (appsData?.length) {
+    if (appsData?.length >= MAX_USER_APPS) {
       const [userApp] = appsData
 
       history.push(`/app/${userApp.appId}`)


### PR DESCRIPTION
We chose this number so people can have a few mainnet/testnet options live at the same time. Locks the backend to error out if a user ever tries to create more apps than this, and also restricts it from the frontend.