### PR TITLE
Frontend: disable app creation

### DIFF
--- a/packages/frontend/src/components/MenuPanel/MenuPanel.js
+++ b/packages/frontend/src/components/MenuPanel/MenuPanel.js
@@ -79,9 +79,9 @@ export default function MenuPanel({ appsLoading = true, userApps = [] }) {
       }))
     )
 
-    if (userApps.length < MAX_USER_APPS) {
-      groups[1].push(...CREATE_APP_ROUTE)
-    }
+    // if (userApps.length < MAX_USER_APPS) {
+    //   groups[1].push(...CREATE_APP_ROUTE)
+    // }
 
     return groups
   }, [userApps])

--- a/packages/frontend/src/views/Dashboard/Create/Create.js
+++ b/packages/frontend/src/views/Dashboard/Create/Create.js
@@ -173,7 +173,7 @@ export default function Create() {
           data: { chains },
         } = res
 
-        return chains
+        return []
       } catch (err) {
         if (sentryEnabled) {
           Sentry.configureScope((scope) => {
@@ -402,12 +402,7 @@ function BasicSetup({
         }
         secondary={
           <>
-            <Button
-              wide
-              onClick={onCreateApp}
-              disabled={isCreateDisabled}
-              mode="strong"
-            >
+            <Button wide onClick={onCreateApp} disabled={true} mode="strong">
               Launch Application
             </Button>
             <Spacer size={2 * GU} />


### PR DESCRIPTION
Until the new workers are in, we need to avoid creating new apps so no "minimally staked" apps are taken.