### PR TITLE
MenuPanel: push create button always

### DIFF
--- a/packages/frontend/src/components/MenuPanel/MenuPanel.js
+++ b/packages/frontend/src/components/MenuPanel/MenuPanel.js
@@ -67,6 +67,10 @@ export default function MenuPanel({ appsLoading = true, userApps = [] }) {
 
     groups.push([MENU_ROUTES[1]])
 
+    if (userApps.length < MAX_USER_APPS) {
+      groups[1].push(...CREATE_APP_ROUTE)
+    }
+
     if (!userApps.length) {
       return groups
     }
@@ -78,10 +82,6 @@ export default function MenuPanel({ appsLoading = true, userApps = [] }) {
         appId: id,
       }))
     )
-
-    if (userApps.length < MAX_USER_APPS) {
-      groups[1].push(...CREATE_APP_ROUTE)
-    }
 
     return groups
   }, [userApps])


### PR DESCRIPTION
Fixes the current bug on the Menu Panel—the create button should always be there.