### PR TITLE
Frontend: default latency chart ms to 0 if there's no info

### DIFF
--- a/packages/frontend/src/views/Dashboard/ApplicationDetail/AppInfo.js
+++ b/packages/frontend/src/views/Dashboard/ApplicationDetail/AppInfo.js
@@ -247,13 +247,16 @@ export default function AppInfo({
     latestLatencyData,
   ])
 
-  const avgLatency = useMemo(
-    () =>
+  const avgLatency = useMemo(() => {
+    if (!latestLatencyData.length) {
+      return 0
+    }
+    return (
       latestLatencyData.reduce((avg, { latency }) => {
         return avg + latency
-      }, 0) / latestLatencyData.length,
-    [latestLatencyData]
-  )
+      }, 0) / latestLatencyData.length
+    )
+  }, [latestLatencyData])
 
   const isSwitchable = useMemo(() => {
     dayjs.extend(dayJsutcPlugin)


### PR DESCRIPTION
Right now, without data, the chart's presenting NaN, which is of course undesirable :).