### PR TITLE
Metrics: show the higher stat for relay count only

### DIFF
--- a/packages/frontend/src/views/Dashboard/Network/NetworkStatus.js
+++ b/packages/frontend/src/views/Dashboard/Network/NetworkStatus.js
@@ -154,7 +154,10 @@ export default function NetworkStatus() {
                         `}
                       >
                         {Intl.NumberFormat().format(
-                          successRateData.totalRelays
+                          Math.min(
+                            successRateData.totalRelays,
+                            successRateData.successfulRelays
+                          )
                         )}
                       </h4>
                       <h5


### PR DESCRIPTION
Due to a technicality in how metrics and relays are sent, sometimes the success rate can be higher than 100% due to relays skipping sessions entirely if they're giving a bad service. This prevents a discrepancy between total and successful relays.